### PR TITLE
There is no need to use old version of maven-war-plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,9 @@
         <connection>scm:git:git@github.com:Alfresco/alfresco-super-pom</connection>
         <developerConnection>scm:git:git@github.com:Alfresco/alfresco-super-pom</developerConnection>
         <url>https://github.com/Alfresco/alfresco-super-pom</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
+
     <distributionManagement>
         <repository>
             <id>alfresco-internal</id>
@@ -256,8 +257,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-war-plugin</artifactId>
-                    <!-- Avoid 3.0.0, which is not compatible with the Alfresco SDK -->
-                    <version>2.6</version>
+                    <version>3.2.3</version>
                     <configuration>
                         <archive>
                             <manifest>


### PR DESCRIPTION
Hi.

If the version of `maven-war-plugins` in alfresco-super-pom is old, the following warning will be output when building other modules that use it.

```
[INFO] --- maven-war-plugin:2.6:war (default-war) @ alfresco-file-transfer-receiver ---
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.thoughtworks.xstream.converters.collections.TreeMapConverter (file:/Users/ey/.m2/repository/com/thoughtworks/xstream/xstream/1.4.4/xstream-1.4.4.jar) to field java.util.TreeMap.comparator
WARNING: Please consider reporting this to the maintainers of com.thoughtworks.xstream.converters.collections.TreeMapConverter
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```

If the version of `maven-war-plugins` is 3.0.0, it seems that the old one was used because it is incompatible with Alfresco SDK. In the current Alfresco SDK,` maven-war-plugins` It is not used.
Therefore, there should be no problem changing to the latest version.

ref: [#433 - SDK 2.2.0 not compatible with maven-war-plugin 3.0.0](https://github.com/Alfresco/alfresco-sdk/issues/433#issue-189170590)

How about this?